### PR TITLE
feat(button,package): add class-variance-authority lib, convert button component to use it

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ pnpm install @hotosm/ui
 ## Usage
 
 ```js
-import Button from '@hotosm/ui';
+import { Button } from '@hotosm/ui';
 
 const HomePage = ({}) => {
   return (

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "typescript": "^5.2.2"
   },
   "dependencies": {
+    "class-variance-authority": "^0.7.0",
     "clsx": "^2.0.0",
     "react": "^18.2.0",
     "tailwind-merge": "^1.14.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,6 +5,9 @@ settings:
   excludeLinksFromLockfile: false
 
 dependencies:
+  class-variance-authority:
+    specifier: ^0.7.0
+    version: 0.7.0
   clsx:
     specifier: ^2.0.0
     version: 2.0.0
@@ -1300,6 +1303,12 @@ packages:
     optionalDependencies:
       fsevents: 2.3.3
     dev: true
+
+  /class-variance-authority@0.7.0:
+    resolution: {integrity: sha512-jFI8IQw4hczaL4ALINxqLEXQbWcNjoSkloa4IaufXCJr6QawJyw7tuRysRsrE8w2p/4gGaxKIt/hX3qz/IbD1A==}
+    dependencies:
+      clsx: 2.0.0
+    dev: false
 
   /classnames@2.3.2:
     resolution: {integrity: sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw==}

--- a/src/button/Button.stories.tsx
+++ b/src/button/Button.stories.tsx
@@ -15,4 +15,15 @@ ButtonStory.argTypes = {
     },
     defaultValue: false,
   },
+  intent: {
+    options: ["primary", "secondary"],
+    control: {
+      type: "select",
+      labels: {
+        primary: "Primary",
+        secondary: "Secondary",
+      }
+    },
+    defaultValue: "primary",
+  }
 };

--- a/src/button/Button.stories.tsx
+++ b/src/button/Button.stories.tsx
@@ -22,8 +22,8 @@ ButtonStory.argTypes = {
       labels: {
         primary: "Primary",
         secondary: "Secondary",
-      }
+      },
     },
     defaultValue: "primary",
-  }
+  },
 };

--- a/src/button/Button.tsx
+++ b/src/button/Button.tsx
@@ -1,33 +1,39 @@
 import { cn } from "@/utils/merge.js";
-import {cva, VariantProps} from "class-variance-authority";
+import { cva, VariantProps } from "class-variance-authority";
 
-export interface ButtonProps extends React.HTMLAttributes<HTMLButtonElement>, VariantProps<typeof buttonStyle> {
+export interface ButtonProps
+  extends React.HTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof buttonStyle> {
   disabled?: boolean;
 }
 
-const buttonStyle = cva("bg-primary text-white py-3 px-6 rounded leading-[1.15]", {
-  variants: {
-    intent: {
-      primary: "bg-primary text-white",
-      secondary: "bg-secondary text-white",
+const buttonStyle = cva(
+  "bg-primary text-white py-3 px-6 rounded leading-[1.15]",
+  {
+    variants: {
+      intent: {
+        primary: "bg-primary text-white",
+        secondary: "bg-secondary text-white",
+      },
+      disabled: {
+        true: "opacity-50 cursor-not-allowed",
+        false: "",
+      },
     },
-    disabled: {
-      true: "opacity-50 cursor-not-allowed",
-      false: "",
-    }
-  }
-})
+  },
+);
 
 export const Button = (props: ButtonProps) => {
   const { className, intent, ...rest } = props;
 
   return (
     <button
-      className={cn(buttonStyle({
-        disabled: props.disabled,
-        intent: intent,
-        className: className,
-      }),
+      className={cn(
+        buttonStyle({
+          disabled: props.disabled,
+          intent: intent,
+          className: className,
+        }),
         className,
       )}
       {...rest}

--- a/src/button/Button.tsx
+++ b/src/button/Button.tsx
@@ -1,18 +1,33 @@
 import { cn } from "@/utils/merge.js";
+import {cva, VariantProps} from "class-variance-authority";
 
-export interface ButtonProps extends React.HTMLAttributes<HTMLButtonElement> {
+export interface ButtonProps extends React.HTMLAttributes<HTMLButtonElement>, VariantProps<typeof buttonStyle> {
   disabled?: boolean;
 }
 
+const buttonStyle = cva("bg-primary text-white py-3 px-6 rounded leading-[1.15]", {
+  variants: {
+    intent: {
+      primary: "bg-primary text-white",
+      secondary: "bg-secondary text-white",
+    },
+    disabled: {
+      true: "opacity-50 cursor-not-allowed",
+      false: "",
+    }
+  }
+})
+
 export const Button = (props: ButtonProps) => {
-  const { className, ...rest } = props;
+  const { className, intent, ...rest } = props;
 
   return (
     <button
-      className={cn(
-        `bg-primary text-white py-3 px-6 rounded leading-[1.15] ${
-          props.disabled ? "opacity-50 cursor-not-allowed" : ""
-        }`,
+      className={cn(buttonStyle({
+        disabled: props.disabled,
+        intent: intent,
+        className: className,
+      }),
         className,
       )}
       {...rest}


### PR DESCRIPTION
### Summary of CVA

The goal of CVA is to manage styling for different variants of a component more easily (e.g. colors, sizes, and styles), with better consistency.
This removes the need to manage dynamic classes manually.

Variants are defined in the component as classes, and a default variant is also set.
Tailwind-merge can resolve conflicts in classes defined by CVA.

### Example

```js
const buttonClass = computed(() => {
  return cva(
    "h-10 px-4", // default classes which are *always* applied
    {
      variants: {
        intent: {
          text: 'text-gray-400' // applied if intent === 'text'
        },
        disabled: {
          true: 'cursor-not-allowed' // applied if disabled === true
        }
      },
      compoundVariants: [ // classes apply if all conditions are true
        {intent: 'primary', disabled: false, class: 'bg-blue-700 text-white hover:bg-blue-600'},
        {intent: 'secondary', disabled: false, class: 'bg-gray-100 text-black hover:bg-gray-50'},
        {intent: ['primary', 'secondary'], disabled: true, class: 'bg-gray-100 text-gray-400'}
      ]
    }
  )({
    intent: props.intent, // pass variant values. eg: "primary", "secondary", "text"
    disabled: props.disabled // pass variant values. eg: false, true
  });
});
```
