### PR TITLE
Add `setBasePath` util function to allow changing icon import path

### DIFF
--- a/components/index.ts
+++ b/components/index.ts
@@ -1,6 +1,8 @@
 // Index to import all components together
 // import '@hotosm/ui/components';
 
+import { setBasePath } from '@shoelace-style/shoelace/dist/utilities/base-path.js';
+
 // Default Shoelace exports
 import SlAlert from '@shoelace-style/shoelace/dist/components/alert/alert.component.js';
 import SlAnimatedImage from '@shoelace-style/shoelace/dist/components/animated-image/animated-image.component.js';
@@ -194,6 +196,9 @@ declare global {
 }
 
 export {
+    // setBasePath helper to use the UI behind proxies etc
+    setBasePath,
+    // Standard shoelace components
     SlAlert,
     SlAnimatedImage,
     SlAnimation,


### PR DESCRIPTION
### Problem

- I am using the UI on a frontend behind a proxy, under the path `/mapnow` on the server.
- I can load the JS without issues, but loading the icons I need in my app fails, as it looks for them under the normal path: 
    `http://MY_DOMAIN:7050/shoelace/assets/icons/map.svg`
    when it should be looking under
    `http://MY_DOMAIN:7050/mapnow/shoelace/assets/icons/map.svg`

    My dir structure:

    ![image](https://github.com/user-attachments/assets/17e4a543-b9ae-4b99-a80d-47256558489d)

- Shoelace already provides a util function to handle this use case: https://shoelace.style/getting-started/installation#setting-the-base-path
- However, because we are **re-exporting** shoelace, using this function as it is will not work.

### Solution

- Re-export the util function from shoelace, so we can use it like this:

    ```js
    import { setBasePath } from '@hotosm/ui/dist/components';
    setBasePath('/mapnow');
    ```