### PR TITLE
refactor: convert header and consent components to mobile first CSS and fix header styling issues

### DIFF
--- a/.storybook/stories/header.stories.ts
+++ b/.storybook/stories/header.stories.ts
@@ -36,6 +36,9 @@ const fiveTab = Array.from({ length: 5 }, (_, index) => ({
 const meta: Meta = {
   title: "Header",
   component: "hot-header",
+  parameters: {
+    layout: "fullscreen",
+  },
   argTypes: {
     title: { control: 'text' },
     size: {

--- a/src/components/consent/consent.styles.ts
+++ b/src/components/consent/consent.styles.ts
@@ -17,7 +17,7 @@ export default css`
     display: flex;
     align-items: center;
     justify-content: center;
-    padding: 1rem;
+    padding: 0.25rem;
     animation: fadeIn 0.3s ease-out;
   }
 
@@ -32,7 +32,7 @@ export default css`
 
   .consent-container {
     width: 100%;
-    max-width: 600px;
+    max-width: 100%;
     animation: slideUp 0.4s ease-out;
   }
 
@@ -75,12 +75,12 @@ export default css`
   }
 
   .consent-content {
-    padding: 1.5rem;
+    padding: 0.75rem;
   }
 
   .consent-header {
     font-weight: 600;
-    font-size: 1.5rem;
+    font-size: 1.125rem;
     line-height: 1.3;
     margin: 0 0 1rem 0;
     color: #1f2937;
@@ -94,7 +94,7 @@ export default css`
 
   .consent-message p {
     margin: 0 0 1rem 0;
-    font-size: 1rem;
+    font-size: 0.875rem;
     line-height: 1.6;
     color: #4b5563;
   }
@@ -105,13 +105,15 @@ export default css`
 
   .consent-actions {
     display: flex;
-    gap: 1rem;
+    flex-direction: column;
+    gap: 0.75rem;
     justify-content: center;
     flex-wrap: wrap;
   }
 
   .consent-button {
-    min-width: 120px;
+    width: 100%;
+    min-width: auto;
     font-weight: 500;
     transition: all 0.2s ease;
     border-radius: 8px;
@@ -144,53 +146,6 @@ export default css`
     border-color: var(--hot-color-red-700);
   }
 
-  /* Responsive design */
-  @media (max-width: 768px) {
-    .consent-overlay {
-      padding: 0.5rem;
-    }
-
-    .consent-container {
-      max-width: 100%;
-    }
-
-    .consent-content {
-      padding: 1rem;
-    }
-
-    .consent-header {
-      font-size: 1.25rem;
-    }
-
-    .consent-actions {
-      flex-direction: column;
-      gap: 0.75rem;
-    }
-
-    .consent-button {
-      width: 100%;
-      min-width: auto;
-    }
-  }
-
-  @media (max-width: 480px) {
-    .consent-overlay {
-      padding: 0.25rem;
-    }
-
-    .consent-content {
-      padding: 0.75rem;
-    }
-
-    .consent-header {
-      font-size: 1.125rem;
-    }
-
-    .consent-message p {
-      font-size: 0.875rem;
-    }
-  }
-
   /* Focus styles for accessibility */
   .consent-button:focus {
     outline: 2px solid var(--hot-color-red-500);
@@ -215,6 +170,56 @@ export default css`
     .consent-button {
       animation: none;
       transition: none;
+    }
+  }
+
+  /* Responsive design for larger screens */
+  @media (min-width: 481px) {
+    .consent-overlay {
+      padding: 0.5rem;
+    }
+
+    .consent-content {
+      padding: 1rem;
+    }
+
+    .consent-header {
+      font-size: 1.25rem;
+    }
+
+    .consent-message p {
+      font-size: 1rem;
+    }
+
+    .consent-actions {
+      gap: 1rem;
+    }
+  }
+
+  @media (min-width: 769px) {
+    .consent-overlay {
+      padding: 1rem;
+    }
+
+    .consent-container {
+      max-width: 600px;
+    }
+
+    .consent-content {
+      padding: 1.5rem;
+    }
+
+    .consent-header {
+      font-size: 1.5rem;
+    }
+
+    .consent-actions {
+      flex-direction: row;
+    }
+
+    .consent-button {
+      width: auto;
+      min-width: 120px;
     }
   }
 `;

--- a/src/components/header/header.styles.ts
+++ b/src/components/header/header.styles.ts
@@ -25,9 +25,10 @@ export type sizes = "small" | "medium" | "large";
 export const styles = css`
   .header {
     display: flex;
-    align-items: center;
+    align-items: stretch;
     justify-content: space-between;
-    padding: 0 var(--hot-spacing-small);
+    height: auto;
+    padding: var(--hot-spacing-small);
   }
 
   .header.border-bottom {
@@ -50,14 +51,15 @@ export const styles = css`
     text-decoration: none;
     display: flex;
     align-items: center;
-    justify-content: space-between;
-    gap: var(--hot-spacing-small);
+    justify-content: flex-start;
+    padding-right: var(--hot-spacing-2x-small);
+    gap: var(--hot-spacing-x-small);
   }
 
   .header--title {
     color: var(--hot-color-neutral-950);
     font-family: var(--hot-font-sans);
-    font-size: var(--hot-font-size-x-large);
+    font-size: var(--hot-font-size-large);
   }
 
   .header--tab::part(base) {
@@ -94,13 +96,13 @@ export const styles = css`
   }
 
   .header--nav {
-    justify-content: space-between;
-    justify-items: center;
-    gap: var(--hot-spacing-medium);
-    font-weight: var(--hot-font-weight-semibold);
+    display: none;
   }
 
   .header--nav-mobile {
+    display: block;
+    width: 100%;
+    margin-top: var(--hot-spacing-small);
   }
 
   .header--person-circle {
@@ -114,10 +116,20 @@ export const styles = css`
   .header--right-section {
     display: flex;
     align-items: center;
-    gap: var(--hot-spacing-small);
+    justify-content: flex-end;
+    gap: var(--hot-spacing-x-small);
   }
 
   .header--logo-img {
+    max-height: 2.5rem;
+    width: auto;
+  }
+
+  wa-button[appearance="outlined"] {
+    /* Make drawer button larger for touch */
+    min-width: 2.5rem;
+    min-height: 2.5rem;
+    padding: 0.5rem;
   }
 
   /* Login Modal Styles */
@@ -127,44 +139,51 @@ export const styles = css`
     --background-color: white;
   }
 
-  /* --- Responsive styles for mobile --- */
-  @media (max-width: 768px) {
+  /* --- Responsive styles for tablet and desktop --- */
+  @media (min-width: 769px) {
     .header {
-      align-items: stretch;
-      width: 100%;
-      padding: var(--hot-spacing-small);
+      align-items: center;
+      padding: 0 var(--hot-spacing-small);
       height: auto;
     }
+
     .header--link {
-      justify-content: flex-start;
-      padding-right: var(--hot-spacing-2x-small);
-      gap: var(--hot-spacing-x-small);
+      justify-content: space-between;
+      padding-right: 0;
+      gap: var(--hot-spacing-small);
     }
+
     .header--title {
-      font-size: var(--hot-font-size-large);
+      font-size: var(--hot-font-size-x-large);
     }
+
     .header--nav {
+      display: flex;
+      justify-content: space-between;
+      justify-items: center;
+      gap: var(--hot-spacing-medium);
+      font-weight: var(--hot-font-weight-semibold);
+    }
+
+    .header--nav-mobile {
       display: none;
     }
-    .header--nav-mobile {
-      display: block;
-      width: 100%;
-      margin-top: var(--hot-spacing-small);
-    }
+
     .header--right-section {
-      justify-content: flex-end;
-      margin-top: var(--hot-spacing-small);
-      gap: var(--hot-spacing-x-small);
+      justify-content: center;
+      margin-top: 0;
+      gap: var(--hot-spacing-small);
     }
+
     .header--logo-img {
-      max-height: 2.5rem;
+      max-height: none;
       width: auto;
     }
+
     wa-button[appearance="outlined"] {
-      /* Make drawer button larger for touch */
-      min-width: 2.5rem;
-      min-height: 2.5rem;
-      padding: 0.5rem;
+      min-width: auto;
+      min-height: auto;
+      padding: initial;
     }
   }
 `;

--- a/src/components/header/header.styles.ts
+++ b/src/components/header/header.styles.ts
@@ -28,7 +28,7 @@ export const styles = css`
     align-items: stretch;
     justify-content: space-between;
     height: auto;
-    padding: var(--hot-spacing-small);
+    padding: 0 var(--hot-spacing-small);
   }
 
   .header.border-bottom {
@@ -143,7 +143,6 @@ export const styles = css`
   @media (min-width: 769px) {
     .header {
       align-items: center;
-      padding: 0 var(--hot-spacing-small);
       height: auto;
     }
 


### PR DESCRIPTION
## Summary
Refactored header and consent overlay components to follow mobile first CSS design principles and fixed header styling issues.

Fixes #148
Fixes #153

### Mobile First Refactor (#148)
- **Header Component**: Converted from desktop first (max-width) to mobile first (min-width) media queries
  - Base styles now target mobile screens (< 769px)
  - Desktop styles applied via `@media (min-width: 769px)`
- **Consent Overlay Component**: Converted to mobile first approach
  - Base styles target smallest screens (< 481px)
  - Progressive enhancement for larger screens via `@media (min-width: 481px)` and `@media (min-width: 769px)`

### Header Styling Fixes (#153)
- Fixed header padding inheritance issue in Storybook by configuring `layout: 'fullscreen'` parameter
- Removed unnecessary width, margin, and positioning properties that were attempting to break out of parent container
- Simplified header CSS for cleaner, more maintainable code

**Note**: When implementing the header component, ensure it is placed outside of any padded containers (not inside the main app component with padding). The header should be positioned at the root level of your application layout to avoid inheriting unwanted padding from parent elements.

### Benefits
- **Better mobile performance**: Mobile styles load first without being overridden
- **Improved maintainability**: Follows industry standard mobile first approach
- **Proper Storybook rendering**: Header displays correctly in preview without gaps or padding issues
- **Cleaner code**: Simplified CSS structure with mobile as the baseline

### Testing
- Verified in Storybook across mobile, tablet, and desktop breakpoints
- Confirmed header spans correctly without padding issues at all screen sizes